### PR TITLE
Update Ruby to version 4.0.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -455,4 +455,4 @@ RUBY VERSION
   ruby 4.0.5
 
 BUNDLED WITH
-  4.0.14
+  4.0.15


### PR DESCRIPTION
This PR updates the Ruby version to 4.0.5.

Changes made:
- Updated .ruby-version file (if present)
- Updated .tool-versions file (if present)
- Updated Gemfile ruby version (if present)
- Updated Dockerfile ruby version (if present)
- Updated Gemfile.lock dependencies
- Updated bundler to latest version

Please review and test before merging.

Powered by [Ruby Upgrade Action](https://github.com/andrew/ruby-upgrade-action/)